### PR TITLE
fix compiling libsup++ on osx with arm-none-eabi

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -21,7 +21,7 @@ if test "$with_fpu" = yes; then
 	psp2dir="$psp2dir/fpu"
 fi
 
-CXXFLAGS="$CXXFLAGS -I$prefix/arm-none-eabi/include $CFLAGS"
+CXXFLAGS="$CXXFLAGS -I$prefix/arm-none-eabi/include/c++/5.1.0/arm-none-eabi $CFLAGS"
 AC_SUBST(psp2dir, $psp2dir)
 
 # Checks for programs.

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -21,7 +21,7 @@ if test "$with_fpu" = yes; then
 	psp2dir="$psp2dir/fpu"
 fi
 
-CXXFLAGS="$CXXFLAGS $CFLAGS"
+CXXFLAGS="$CXXFLAGS -I$prefix/arm-none-eabi/include $CFLAGS"
 AC_SUBST(psp2dir, $psp2dir)
 
 # Checks for programs.


### PR DESCRIPTION
need to add c++ toolchain include in CXXFLAGS
